### PR TITLE
Add documentCallback option + path attribute

### DIFF
--- a/source.js
+++ b/source.js
@@ -2261,14 +2261,14 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
                 currentElem._pos[j].hidden = true;
               } else {
                 let pointOnPath = pathObject.getPointAtLength(charMidX * pathScale);
-                currentElem._pos[j].x = pointOnPath[0] - 0.5 * currentElem._pos[j].width * Math.cos(pointOnPath[2]) - currentElem._pos[j].y * Math.sin(pointOnPath[2]);
-                currentElem._pos[j].y = pointOnPath[1] - 0.5 * currentElem._pos[j].width * Math.sin(pointOnPath[2]) + currentElem._pos[j].y * Math.cos(pointOnPath[2]);
-                currentElem._pos[j].rotate = pointOnPath[2] + currentElem._pos[j].rotate;
-                currentElem._pos[j].continuous = false;
                 if (isNotEqual(pathScale, 1)) {
                   currentElem._pos[j].scale *= pathScale;
                   currentElem._pos[j].width *= pathScale;
                 }
+                currentElem._pos[j].x = pointOnPath[0] - 0.5 * currentElem._pos[j].width * Math.cos(pointOnPath[2]) - currentElem._pos[j].y * Math.sin(pointOnPath[2]);
+                currentElem._pos[j].y = pointOnPath[1] - 0.5 * currentElem._pos[j].width * Math.sin(pointOnPath[2]) + currentElem._pos[j].y * Math.cos(pointOnPath[2]);
+                currentElem._pos[j].rotate = pointOnPath[2] + currentElem._pos[j].rotate;
+                currentElem._pos[j].continuous = false;
               }
             }
           } else {

--- a/source.js
+++ b/source.js
@@ -541,9 +541,9 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
         return lengthMap;
       })();
       let totalLength = this.totalLength = lengthMap[divisions];
-      this.startPoint = [p1x, p1y, isEqual(p1x, c1x) && isEqual(p1y, c1y) ? 
+      this.startPoint = [p1x, p1y, isEqual(p1x, c1x) && isEqual(p1y, c1y) ?
                                Math.atan2(c2y - c1y, c2x - c1x) : Math.atan2(c1y - p1y, c1x - p1x)];
-      this.endPoint = [p2x, p2y, isEqual(c2x, p2x) && isEqual(c2y, p2y) ? 
+      this.endPoint = [p2x, p2y, isEqual(c2x, p2x) && isEqual(c2y, p2y) ?
                                Math.atan2(c2y - c1y, c2x - c1x) : Math.atan2(p2y - c2y, p2x - c2x)];
       this.boundingBox = (function() {
         let temp;
@@ -1122,8 +1122,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
                 value = (value || '').split(' ');
                 let object = this.resolveUrl(value[0]),
                     fallbackColor = parseColor(value[1]);
-                if (object === undefined) {return;}           // resolveUrl() returns undefined if the string has not a correct url syntax
-                if (object === null) {return fallbackColor;}  // and it returns null if the syntax looks good but the element was not found
+                if (object === undefined) {return fallbackColor;}
                 if (object.nodeName === 'linearGradient' || object.nodeName === 'radialGradient') {
                   return new SvgElemGradient(object, null, fallbackColor);
                 }
@@ -1601,7 +1600,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
           if (spread === 'reflect' || spread === 'repeat') {
             let inv = inverseMatrix(matrix),
                 corner1 = transformPoint([bBox[0], bBox[1]], inv),
-                corner2 = transformPoint([bBox[2], bBox[1]], inv),  
+                corner2 = transformPoint([bBox[2], bBox[1]], inv),
                 corner3 = transformPoint([bBox[2], bBox[3]], inv),
                 corner4 = transformPoint([bBox[0], bBox[3]], inv);
             if (this.name === 'linearGradient') { // See file 'gradient-repeat-maths.png'

--- a/source.js
+++ b/source.js
@@ -51,11 +51,9 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       doc.page.ext_gstates[name] = gstate;
       doc.addContent('/' + name + ' gs');
     };
-    function docCreatePattern(group, x, y, dx, dy, matrix) {
+    function docCreatePattern(group, dx, dy, matrix) {
       let pattern = new (function PDFPattern() {})();
       pattern.group = group;
-      pattern.x = x;
-      pattern.y = y;
       pattern.dx = dx;
       pattern.dy = dy;
       pattern.matrix = matrix || [1, 0, 0, 1, 0, 0];
@@ -65,7 +63,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       let name = 'P' + (++patternCount);
       let ref = doc.ref({
         Type: 'Pattern', PatternType: 1, PaintType: 1, TilingType: 2,
-        BBox: [pattern.x, pattern.y, pattern.dx, pattern.dy], XStep: pattern.dx, YStep: pattern.dy,
+        BBox: [0, 0, pattern.dx, pattern.dy], XStep: pattern.dx, YStep: pattern.dy,
         Matrix: multiplyMatrix(doc._ctm, pattern.matrix),
         Resources: {
           ProcSet: ['PDF', 'Text', 'ImageB', 'ImageC', 'ImageI'],
@@ -1527,7 +1525,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
           doc.transform.apply(doc, aspectRatioMatrix);
           this.drawChildren(isClip, isMask);
           docEndGroup(group);
-          return [docCreatePattern(group, 0, 0, width, height, matrix), gOpacity];
+          return [docCreatePattern(group, width, height, matrix), gOpacity];
         } else {
           return fallback ? [fallback.slice(0, 3), fallback[3] * gOpacity] : undefined;
         }

--- a/source.js
+++ b/source.js
@@ -323,6 +323,9 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
     function validateNumber(n) {
       return n > -1e21 && n < 1e21 ? Math.round(n * 1e6) / 1e6 : 0;
     }
+    function isArrayLike(v) {
+      return typeof v === 'object' && v !== null && typeof v.length === 'number';
+    }
     function parseTranform(v) {
       let parser = new StringParser((v || '').trim()), result = [1, 0, 0, 1, 0, 0], temp;
       while (temp = parser.match(/^([A-Za-z]+)[(]([^(]+)[)]/, true)) {
@@ -968,7 +971,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
             let svgs = documentCache[file];
             if (!svgs) {
               svgs = documentCallback(file);
-              if (!Array.isArray(svgs)) {svgs = [svgs];}
+              if (!isArrayLike(svgs)) {svgs = [svgs];}
               for (let i = 0; i < svgs.length; i++) {
                 if (typeof svgs[i] === 'string') {svgs[i] = parseXml(svgs[i]);}
               }


### PR DESCRIPTION
The documentCallback option is useful when external files are used, for example with <textPath href="myExternalFile.svg#myPath">.
It's a function that takes the URL of the external file as argument and returns the corresponding SVG as string or SVGElement.
If the URL points to an HTML file with multiple embedded SVGs, an Array with all the SVGs should be returned.
Then, SVGtoPDFKit parses the SVG returned by the documentCallback function and searches the first element with matching id.
NOTE: The documentCallback function must be synchronous (use readFileSync in Node, pre-fetch or use a web worker in the browser).

Close #58 