### PR TITLE
Add color callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Insert SVG into a PDF document created with PDFKit.
 ## Use
 
     SVGtoPDF(doc, svg, x, y, options);
-    
+
 &nbsp; &nbsp; If you prefer, you can add the function to the PDFDocument prototype:
 
     PDFDocument.prototype.addSVG = function(svg, x, y, options) {
@@ -16,7 +16,7 @@ Insert SVG into a PDF document created with PDFKit.
     };
 
 &nbsp; &nbsp; And then simply call:
-    
+
     doc.addSVG(svg, x, y, options);
 
 ## Parameters
@@ -30,6 +30,7 @@ Insert SVG into a PDF document created with PDFKit.
       - useCSS [boolean] = use the CSS styles computed by the browser (for SVGElement only)
       - fontCallback [function] = function called to get the fonts, see source code
       - imageCallback [function] = same as above for the images (for Node.js)
+      - colorCallback [function] = function called to get color, making mapping RGB to HEX colors possible
       - warningCallback [function] = function called when there is a warning
       - assumePt [boolean] = assume that units are PDF points instead of SVG pixels
       - precision [number] = precision factor for approximative calculations (default = 3)
@@ -67,7 +68,7 @@ Insert SVG into a PDF document created with PDFKit.
 ## Warning
  - Use an updated PDFKit version (≥0.8.1): see <a href="https://github.com/alafr/pdfkit/wiki/How-to-install-and-build-a-PDFKit-branch">here</a> how to build it, or use the prebuilt file in the <a href="https://github.com/alafr/SVG-to-PDFKit/tree/master/examples">examples</a> folder.
  - There are bugs, please send issues and/or pull requests.
- 
+
 ## License
 &nbsp; &nbsp; <a href="http://choosealicense.com/licenses/mit/">MIT</a>
 

--- a/source.js
+++ b/source.js
@@ -102,7 +102,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
         doc.fillOpacity(opacity);
         docUsePattern(color, false);
       } else {
-        doc.fillColor(color, opacity);
+        doc.fillColor(colorCallback(color), opacity);
       }
     }
     function docStrokeColor(color, opacity) {
@@ -110,7 +110,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
         doc.strokeOpacity(opacity);
         docUsePattern(color, true);
       } else {
-        doc.strokeColor(color, opacity);
+        doc.strokeColor(colorCallback(color), opacity);
       }
     }
     function parseXml(xml) {
@@ -2324,6 +2324,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
         warningCallback = options.warningCallback,
         fontCallback = options.fontCallback,
         imageCallback = options.imageCallback,
+        colorCallback = options.colorCallback,
         documentCallback = options.documentCallback,
         precision = Math.ceil(Math.max(1, options.precision)) || 3,
         groupStack = [],
@@ -2360,6 +2361,11 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
     if (typeof imageCallback !== 'function') {
       imageCallback = function(link) {
         return link.replace(/\s+/g, '');
+      };
+    }
+    if (typeof colorCallback !== 'function') {
+      colorCallback = function(color) {
+        return color;
       };
     }
     if (typeof documentCallback !== 'function') {


### PR DESCRIPTION
When creating print ready documents CMYK is often preferred. Since there is no CMYK support in browsers and colors is extracted as RGB values now, RGB values are passed to pdfkit.

This PR adds `colorCallback` as an option that allows the user to map RGB values to something else, like CMYK.

The `colorCallback` function is called with one argument: an array of the RGB components, and is expected to return a color. This color can be RGB or CMYK component arrays: `[R, G, B]` or `[C, M, Y, K]`.

Example:
```js
{
  ...,
  colorCallback: function mapColors(rgb) {
    if (r === 241 && g === 241 && b === 241) {
      return [0, 0, 0, 5]
    }

    return rgb
  },
}
```