### PR TITLE
Update source.js

### DIFF
--- a/source.js
+++ b/source.js
@@ -412,7 +412,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
     }
     function parseTranform(v) {
       let parser = new StringParser((v || '').trim()), result = [1, 0, 0, 1, 0, 0], temp;
-      while (temp = parser.match(/^([A-Za-z]+)[(]([^(]+)[)]/, true)) {
+      while (temp = parser.match(/^([A-Za-z]+)\s*[(]([^(]+)[)]/, true)) {
         let func = temp[1], nums = [], parser2 = new StringParser(temp[2].trim()), temp2;
         while (temp2 = parser2.matchNumber()) {
           nums.push(Number(temp2));


### PR DESCRIPTION
Backus-Naur Form (BNF) for values for the SVG ‘transform’ attribute allows for zero or more whitespace characters between the transform name and the opening brackets - this update allows for that. E.g. transform="scale (2)"

https://www.w3.org/TR/SVG11/coords.html#TransformAttribute 

This is my first PR so please advise if I've done anything incorrectly.