### PR TITLE
fix for dash lines

### DIFF
--- a/source.js
+++ b/source.js
@@ -1834,7 +1834,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
                  .miterLimit(this.get('stroke-miterlimit'))
                  .lineJoin(this.get('stroke-linejoin'))
                  .lineCap(lineCap)
-                 .dash(dashArray, {phase: dashOffset});
+                 .dash(dashArray[0] || '', {phase: dashOffset, space: dashArray[1] || null});
             }
             for (let j = 0; j < subPaths.length; j++) {
               if (subPaths[j].totalLength > 0) {


### PR DESCRIPTION
When I use addSvg method to draw pdf, all dash lines are converted to solid lines.
I took svg example from https://www.w3schools.com/graphics/tryit.asp?filename=trysvg_stroke3
after pdf generation I got 3 solid lines not dashed lines

It appears that dash method is expecting number value not array, while second parameter should be passed as "space" key in options object 

Here is ticket I've created https://github.com/foliojs/pdfkit/issues/875