### PR TITLE
Handle empty SVG paths better

### DIFF
--- a/source.js
+++ b/source.js
@@ -1809,15 +1809,17 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
               for (let j = 0; j < subPaths.length; j++) {
                 if (isEqual(subPaths[j].totalLength, 0)) {
                   if ((lineCap === 'square' || lineCap === 'round') && lineWidth > 0) {
-                    let x = subPaths[j].startPoint[0],
-                        y = subPaths[j].startPoint[1];
-                    docFillColor(stroke);
-                    if (lineCap === 'square') {
-                      doc.rect(x - 0.5 * lineWidth, y - 0.5 * lineWidth, lineWidth, lineWidth);
-                    } else if (lineCap === 'round') {
-                      doc.circle(x, y, 0.5 * lineWidth);
+                    if (subPaths[j].startPoint && subPaths[j].startPoint.length > 1) {
+                      let x = subPaths[j].startPoint[0],
+                          y = subPaths[j].startPoint[1];
+                      docFillColor(stroke);
+                      if (lineCap === 'square') {
+                        doc.rect(x - 0.5 * lineWidth, y - 0.5 * lineWidth, lineWidth, lineWidth);
+                      } else if (lineCap === 'round') {
+                        doc.circle(x, y, 0.5 * lineWidth);
+                      }
+                      doc.fill();
                     }
-                    doc.fill();
                   }
                 }
               }


### PR DESCRIPTION
It seems that a path that contains a single MoveTo command (M) without a connecting line will throw an error:

`Cannot read property '0' of null`

Note that this seems to only happen if a stroke-linecap is specified as round or square.

This type of path throws the error:
`<path fill="none" d="M 10 30" stroke="black" stroke-linecap="round"></path>`

But these do not:
```
<path fill="none" d="M 10 30 L 20 40" stroke="black" stroke-linecap="round"></path>
<path fill="none" d="M 10 30" stroke="black"></path>
```

So I added a truthy check and length check to handle this case
