### PR TITLE
Write text continuously into PDF with TJ command string

### DIFF
--- a/source.js
+++ b/source.js
@@ -2234,6 +2234,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
             let textScale = length / (endX - startX);
             if (textScale > 0 && textScale < Infinity) {
               for (let j = 0; j < pos.length; j++) {
+                pos[j].continuous = false;
                 pos[j].x = startX + textScale * (pos[j].x - startX);
                 pos[j].scale *= textScale;
                 pos[j].width *= textScale;
@@ -2243,6 +2244,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
             if (pos.length >= 2) {
               let spaceDiff = (length - (endX - startX)) / (pos.length - 1);
               for (let j = 0; j < pos.length; j++) {
+                pos[j].continuous = false;
                 pos[j].x += j * spaceDiff;
               }
             }
@@ -2313,6 +2315,8 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
                         dyAttr = currentElem._dy[index],
                         rotAttr = currentElem._rot[index],
                         continuous = !(w === 0 && j === 0);
+                    if (letterSpacing !== 0) {continuous = false}
+                    if (wordSpacing !== 0) {continuous = false}
                     if (xAttr !== undefined) {continuous = false; doAnchoring(); currentX = xAttr;}
                     if (yAttr !== undefined) {continuous = false; doAnchoring(); currentY = yAttr;}
                     if (dxAttr !== undefined) {continuous = false; currentX += dxAttr;}


### PR DESCRIPTION
Hi @alafr
First - a massive thank you for writing & open sourcing this library! 🎉

This PR adapts svg-to-pdfkit to write text to the PDF in batches using the `TJ` text showing command, as opposed to writing each character individually with the `Tj` command proceeded by its full text matrix with `Tm`.

In addition to making the text selection a bit nicer (mentioned by @acthp in issue #111), this will in many cases reduce the resulting PDF size by up to 28 bytes *per character*!

From issue #111:
> the SVG-to-PDFKit code should check for each character if it has only moved in the x direction from the previous one

I've noticed each item in text `pos` array contains a `continuous` boolean attribute, which interestingly isn't actually used anywhere. I assume this attribute is for denoting sequences of text that only differ in the x axis, so I’ve adopted it and used it for this feature.

With this change, if a character in the `pos` array has the continuous attribute set, it will be added into a `TJ` command with only its kerning value added. If it does not, it will be proceeded by its own text matrix command as before.

**Compatibility:**
I’ve used ES6 template strings and the `const` keyword for the first time in this project, I assume this is fine because `let` is used elsewhere.

**Testing:**
Initially my `results.js` file generated from my Chrome (v83, macOS, 64bit) did not match the file in the repo, perhaps it was generated with a different OS/Chrome version, and the tests are not cross-platform? However, running the tests on my machine before & after this change only highlights differences in the [15 known-bad](https://github.com/alafr/SVG-to-PDFKit/tree/master/examples#failed-tests-because-of-bugs-or-missing-features-in-svg-to-pdfkit) tests, which I think counts as a pass.

**References**
[TJ command reference](https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf#page=258)
[PDFkit's text drawing routine](https://github.com/foliojs/pdfkit/blob/386cebb9ffc479b8f748944ee77d78198e5e04a8/lib/mixins/text.js#L384)

I'd be grateful if you (and @acthp?) could give this a test when you have a chance, to see if I've overlooked anything.
Thanks!