### PR TITLE
CMYK color parsing condition (issue #129)

### DIFF
--- a/source.js
+++ b/source.js
@@ -356,6 +356,11 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       raw = (raw || '').trim();
       if (temp = NamedColors[raw]) {
         result = [temp.slice(), 1];
+      } else if (temp = raw.match(/^cmyk\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9.]+)\s*\)$/i)) {
+        temp[1] = parseInt(temp[1]); temp[2] = parseInt(temp[2]); temp[3] = parseInt(temp[3]); temp[4] = parseFloat(temp[4]);
+        if (temp[1] <= 100 && temp[2] <= 100 && temp[3] <= 100 && temp[4] <= 100) {
+          result = [temp.slice(1, 5), 1];
+        }
       } else if (temp = raw.match(/^rgba\(\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9]+)\s*,\s*([0-9.]+)\s*\)$/i)) {
         temp[1] = parseInt(temp[1]); temp[2] = parseInt(temp[2]); temp[3] = parseInt(temp[3]); temp[4] = parseFloat(temp[4]);
         if (temp[1] < 256 && temp[2] < 256 && temp[3] < 256 && temp[4] <= 1) {


### PR DESCRIPTION
An attempt to parse CMYK color and generate CMYK color enabled PDF from SVG

Testing by running `demo.htm` and using SVG code below

```
<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 803 515">
  <defs>
    <style>
      .cls-1 {
        font-size: 52.72px;
        font-family: MyriadPro-Regular, Myriad Pro;
      }

      .cls-2 {
        letter-spacing: -0.01em;
      }

      .cls-3 {
        letter-spacing: 0em;
      }

      .cls-4 {
        letter-spacing: -0.04em;
      }
    </style>
  </defs>
  <title>CMYK BOX</title>
  <rect x="41" y="37" width="223" height="194" fill="cmyk(0, 85, 65, 0)"/>
  <rect x="41" y="285" width="223" height="194" fill="cmyk(90, 55, 0, 0)"/>
  <text class="cls-1" transform="translate(291.32 80.53)" fill="cmyk(0, 85, 65, 0)">THIS SHOULD BE RED</text>
  <text class="cls-1" transform="translate(291.32 329.53)" fill="cmyk(90, 55, 0, 0)">THIS SHOULD BE BLUE</text>
</svg>
```

still unable to parse CSS attribute for example `<g style="fill: cmyk(20,20,90,10)"></g>`