### PR TITLE
More performance by omitting unnecessary call to getBoundingBox for clip path calculation

### DIFF
--- a/source.js
+++ b/source.js
@@ -1376,7 +1376,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       this.clip = function() {
         if (this.get('clip-path') !== 'none') {
           let clipPath = new SvgElemClipPath(this.get('clip-path'), null);
-          clipPath.useMask(this.getBoundingBox());
+          clipPath.useMask((clipPath.attr('clipPathUnits') === 'objectBoundingBox') ? this.getBoundingBox() : null);
           return true;
         }
       };


### PR DESCRIPTION
Fix for issue #141. The bounding box for the clip path is only needed in the case, when the clip-path attribute 'clipPathUnits' is set to 'objectBoundingBox', but was called every time. In bigger SVGs the call to getBoundingBox takes seconds because the bounding shape contains more than 100,000 points. When this call can be omitted, the over-all performance gains up to 90%.