### PR TITLE
Update checking of classList contents

### DIFF
--- a/source.js
+++ b/source.js
@@ -609,7 +609,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
         if (selector.ids[i] !== elem.id) {return false;}
       }
       for (let i = 0; i < selector.classes.length; i++) {
-        if (elem.classList.indexOf(selector.classes[i]) === -1) {return false;}
+        if (!elem.classList.contains(selector.classes[i])) {return false;}
       }
       return true;
     }


### PR DESCRIPTION
### Background
I have an SVG that uses classes and was failing with an error:
`svg-to-pdfkit.js:612   Uncaught TypeError: elem.classList.indexOf is not a function`

### Description
`elem.classList` returns a [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) (see [Element.classList](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList)).
DOMTokenList doesn't have an `indexOf` method which was causing this check to error. 
However it does have a `contains` method, which this PR uses to do an equivalent check.