### PR TITLE
Add support for vector-effect property

### DIFF
--- a/source.js
+++ b/source.js
@@ -60,7 +60,8 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       'display':            {inherit: false, initial: 'inline', values: {'none':'none', 'inline':'inline', 'block':'inline'}},
       'clip-path':          {inherit: false, initial: 'none'},
       'mask':               {inherit: false, initial: 'none'},
-      'overflow':           {inherit: false, initial: 'hidden', values: {'hidden':'hidden', 'scroll':'hidden', 'visible':'visible'}}
+      'overflow':           {inherit: false, initial: 'hidden', values: {'hidden':'hidden', 'scroll':'hidden', 'visible':'visible'}},
+      'vector-effect':      {inherit: true, initial: 'none', values: {'none':'none', 'non-scaling-stroke':'non-scaling-stroke'}}
     };
 
     function docBeginGroup(bbox) {
@@ -1842,7 +1843,11 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       this.drawInDocument = function(isClip, isMask) {
         if (this.get('visibility') === 'hidden' || !this.shape) {return;}
         doc.save();
-        this.transform();
+        if (this.get('vector-effect') === 'non-scaling-stroke') {
+          this.shape.transform(this.getTransformation());
+        } else {
+          this.transform();
+        }
         this.clip();
         if (!isClip) {
           let masked = this.mask(),

--- a/source.js
+++ b/source.js
@@ -421,6 +421,11 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       return new SvgShape().M(0, 0).L(doc.page.width, 0).L(doc.page.width, doc.page.height).L(0, doc.page.height)
                            .transform(inverseMatrix(getGlobalMatrix())).getBoundingBox();
     }
+    function getPageScale() {
+      const bbox = getPageBBox();
+      const width = doc.page.width;
+      return width / bbox[2];
+    }
     function inverseMatrix(m) {
       let dt = m[0] * m[3] - m[1] * m[2];
       return [m[3] / dt, -m[1] / dt, -m[2] / dt, m[0] / dt, (m[2]*m[5] - m[3]*m[4]) / dt, (m[1]*m[4] - m[0]*m[5]) / dt];
@@ -1860,6 +1865,11 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
               stroke = this.getStroke(isClip, isMask),
               lineWidth = this.get('stroke-width'),
               lineCap = this.get('stroke-linecap');
+
+          if (this.get('vector-effect') === 'non-scaling-stroke') {
+            lineWidth = lineWidth / getPageScale();
+          }
+          
           if (fill || stroke) {
             if (fill) {
               docFillColor(fill);


### PR DESCRIPTION
This PR is intended to address the issue noted in #113.

Not being familiar with the SVG-to-PDFKit codebase, it's possible that I've missed cases where this fails; it does seem to work for the example file here: 

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/vector-effect#example_vector-effectnon-scaling-stroke

Only "non-scaling-stroke" and "none" are supported options; according to https://caniuse.com/vector-effect , the other properties are generally unsupported and at risk of being deprecated.