### PR TITLE
Show error message from PDFKit when a font fails to open

### DIFF
--- a/source.js
+++ b/source.js
@@ -2312,7 +2312,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
           try {
             doc.font(fontNameorLink);
           } catch(e) {
-            warningCallback('SVGElemText: failed to open font "' + fontNameorLink + '" in PDFKit');
+            warningCallback('SVGElemText: failed to open font "' + fontNameorLink + '" in PDFKit: ' + e.message);
           }
           currentElem._pos = [];
           currentElem._index = 0;


### PR DESCRIPTION
This changes the current error message:

```
SVGElemText: failed to open font "Source Sans Pro" in PDFKit
```

to add the PDFKit error message, for example: 

```
SVGElemText: failed to open font "Source Sans Pro" in PDFKit: Variations require a font with the fvar, gvar and glyf, or CFF2 tables.
```

This should make it easier to troubleshoot font loading errors.