### PR TITLE
Make PDFKit a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/alafr/SVG-to-PDFKit",
   "bugs": "https://github.com/alafr/SVG-to-PDFKit/issues",
   "main": "source.js",
-  "dependencies": {
+  "devDependencies": {
     "pdfkit": ">=0.8.1"
   }
 }


### PR DESCRIPTION
SVG-to-PDFKit doesn't actually depend on PDFKit at runtime, it expects its consumer to use PDFKit to instantiate a PDFKit PDFDocument and pass it in to SVG-to-PDFKit's API. So the consumer should already have its own dependency on PDFKit, and SVG-to-PDFKit having one just potentially results in an extra unused copy of it in `node_modules`.

I'm not sure that SVG-to-PDFKit even needs a devDependency on PDFKit, but perhaps it makes it easier to regenerate `examples/pdfkit.js`, so probably doesn't really hurt to keep.