### PR TITLE
Fix dominant-baseline computation

### DIFF
--- a/examples/results.js
+++ b/examples/results.js
@@ -4,7 +4,7 @@ var PreviousResults = {
   "additional-test-03.svg": 0,
   "additional-test-04.svg": 0,
   "additional-test-05.svg": 0,
-  "additional-test-06.svg": 0,
+  "additional-test-06.svg": 0.57,
   "additional-test-07.svg": 0,
   "additional-test-08.svg": 0,
   "additional-test-09.svg": 0.7,


### PR DESCRIPTION
`alignment-baseline` has no effect on `<text>` elements, but the baseline computation code was using its value for all elements, including `<text>` elements, if present. With `useCSS: false` this meant that if a style explicitly set `alignment-baseline` on a `<text>` element, it would incorrectly be used (and `dominant-baseline` ignored). With `useCSS: true`, it's even worse because the computed styles for a `<text>` element will always include a value (probably `auto`) for `alignment-baseline` (because computed styles don't know about the semantics of which attributes affect which elements), so the `dominant-baseline` value would always be ignored.

So, the fix is to ignore `alignment-baseline` (and `baseline-shift` while we're at it, which also has no effect on `<text>` elements) when processing `<text>` elements.

This causes a test failure because Chrome (unlike Firefox) incorrectly factors in `alignment-baseline` on `<text>` elements, so I updates the expected results to account for it.