### PR TITLE
Fix pattern support possibly broken by minification

### DIFF
--- a/source.js
+++ b/source.js
@@ -114,11 +114,13 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       doc.addContent('/' + name + ' gs');
     }
     function docCreatePattern(group, dx, dy, matrix) {
-      let pattern = new (function PDFPattern() {})();
-      pattern.group = group;
-      pattern.dx = dx;
-      pattern.dy = dy;
-      pattern.matrix = matrix || [1, 0, 0, 1, 0, 0];
+      let pattern = {
+        type: 'PDFPattern',
+        group: group,
+        dx: dx,
+        dy: dy,
+        matrix: matrix || [1, 0, 0, 1, 0, 0],
+      }
       return pattern;
     }
     function docUsePattern(pattern, stroke) {
@@ -209,7 +211,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       doc.addContent('ET');
     }
     function docFillColor(color) {
-      if (color[0].constructor.name === 'PDFPattern') {
+      if (color[0].type === 'PDFPattern') {
         doc.fillOpacity(color[1]);
         docUsePattern(color[0], false);
       } else {
@@ -217,7 +219,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       }
     }
     function docStrokeColor(color) {
-      if (color[0].constructor.name === 'PDFPattern') {
+      if (color[0].type === 'PDFPattern') {
         doc.strokeOpacity(color[1]);
         docUsePattern(color[0], true);
       } else {


### PR DESCRIPTION
As noted in #137, patterns are sometimes not correctly converted from SVG to PDF: in these cases, patterned areas turn into black solid fill. The issue occurs for example when using production mode from a Create React App configuration.

Digging into this, I found that the generation of PDF patterns relies on a string comparison with the constructor name: 
https://github.com/alafr/SVG-to-PDFKit/blob/d339cecbbee6697c94f6148dc44f21a958493268/source.js#L212

But the constructor in question belongs to a private type inside another function:
https://github.com/alafr/SVG-to-PDFKit/blob/d339cecbbee6697c94f6148dc44f21a958493268/source.js#L117

At least some minifiers are smart enough to realize this name could be removed, causing the constructor name comparison to fail.

I have addressed this by replacing the private class/constructor with a simple object and a `type` property that I set to `PDFPattern`. This resolves the issue and I think it works equally well.

If types/classes are preferred, I guess we could make `PDFPattern` a class known throughout the library and replace the constructor name check with an `instanceof` check.
