### PR TITLE
Fix precedence order of style resolution

### DIFF
--- a/source.js
+++ b/source.js
@@ -1324,15 +1324,15 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
         for (let i = 0; i < 3; i++) {
           switch (i) {
             case 0:
-              if (key !== 'transform') { // the CSS transform behaves strangely
-                value = this.css[keyInfo.css || key];
-              }
+              value = this.attr(key);
               break;
             case 1:
               value = this.style[key];
               break;
             case 2:
-              value = this.attr(key);
+              if (key !== 'transform') { // the CSS transform behaves strangely
+                value = this.css[keyInfo.css || key];
+              }
               break;
           }
           if (value === 'inherit') {

--- a/source.js
+++ b/source.js
@@ -731,7 +731,8 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
         if (selector.ids[i] !== elem.id) {return false;}
       }
       for (let i = 0; i < selector.classes.length; i++) {
-        if (!elem.classList.contains(selector.classes[i])) {return false;}
+        const containMethod = elem.classList instanceof DOMTokenList ? 'contains' : 'includes'
+        if (!elem.classList[containMethod](selector.classes[i])) {return false;}
       }
       return true;
     }

--- a/source.js
+++ b/source.js
@@ -731,7 +731,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
         if (selector.ids[i] !== elem.id) {return false;}
       }
       for (let i = 0; i < selector.classes.length; i++) {
-        const containMethod = elem.classList instanceof DOMTokenList ? 'contains' : 'includes'
+        const containMethod = typeof elem.classList.contains === 'function' ? 'contains' : 'includes'
         if (!elem.classList[containMethod](selector.classes[i])) {return false;}
       }
       return true;


### PR DESCRIPTION
Resolves #170 

Checks for an attribute, then a style declaration, then css

Also makes sure that the classlist can be checked whether it is a `DOMTokenList` or an `Array`