### PR TITLE
Allow usage of font-weight attribute within fontCallback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ declare namespace SVGtoPDF {
         // function called to get the fonts, see source code
         fontCallback?: (
             family: string,
-            bold: boolean,
+            weight: string,
             italic: boolean,
             fontOptions: { fauxItalic: boolean; fauxBold: boolean },
         ) => string

--- a/source.js
+++ b/source.js
@@ -41,7 +41,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       'stroke-linecap':     {inherit: true, initial: 'butt', values: {'butt':'butt', 'round':'round', 'square':'square'}},
       'font-size':          {inherit: true, initial: 16, values: {'xx-small':9, 'x-small':10, 'small':13, 'medium':16, 'large':18, 'x-large':24, 'xx-large':32}},
       'font-family':        {inherit: true, initial: 'sans-serif'},
-      'font-weight':        {inherit: true, initial: 'normal', values: {'600':'bold', '700':'bold', '800':'bold', '900':'bold', 'bold':'bold', 'bolder':'bold', '500':'normal', '400':'normal', '300':'normal', '200':'normal', '100':'normal', 'normal':'normal', 'lighter':'normal'}},
+      'font-weight':        {inherit: true, initial: 'normal', values: {'600':'bold', '700':'bold', '800':'bolder', '900':'bolder', 'bold':'bold', 'bolder':'bolder', '500':'normal', '400':'normal', '300':'normal', '200':'normal', '100':'normal', 'normal':'normal', 'lighter':'normal'}},
       'font-style':         {inherit: true, initial: 'normal', values: {'italic':'italic', 'oblique':'italic', 'normal':'normal'}},
       'text-anchor':        {inherit: true, initial: 'start', values: {'start':'start', 'middle':'middle', 'end':'end'}},
       'direction':          {inherit: true, initial: 'ltr', values: {'ltr':'ltr', 'rtl':'rtl'}},
@@ -2433,7 +2433,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
           currentElem._defRot = currentElem.chooseValue(currentElem._rot[currentElem._rot.length - 1], parentElem && parentElem._defRot, 0);
           if (currentElem.name === 'textPath') {currentElem._y = [];}
           let fontOptions = {fauxItalic: false, fauxBold: false},
-              fontNameorLink = fontCallback(currentElem.get('font-family'), currentElem.get('font-weight') === 'bold', currentElem.get('font-style') === 'italic', fontOptions);
+              fontNameorLink = fontCallback(currentElem.get('font-family'), currentElem.get('font-weight'), currentElem.get('font-style') === 'italic', fontOptions);
           try {
             doc.font(fontNameorLink);
           } catch(e) {


### PR DESCRIPTION
This is a breaking change to the fontCallback method which allows the user to make use of the exact font-weight value of the element rather than just a boolean of whether it is a bold variant.

Font weights of 800 and 900 are now classified as `'bolder'` rather than `'bold'`, so the fontCallback is passed a `weight` string of type: `'normal' | 'bold' | 'bolder'`.