### PR TITLE
Add support for <marker> with orient="auto-start-reverse".

### DIFF
--- a/source.js
+++ b/source.js
@@ -2037,7 +2037,7 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
             let markersPos = this.shape.getMarkers();
             if (markerStart !== 'none' && markersPos.length > 0) {
               let marker = new SvgElemMarker(markerStart, null);
-              marker.drawMarker(false, isMask, markersPos[0], lineWidth);
+              marker.drawMarker(false, isMask, markersPos[0], lineWidth, true);
             }
             if (markerMid !== 'none') {
               for (let i = 1; i < markersPos.length - 1; i++) {
@@ -2173,12 +2173,16 @@ var SVGtoPDF = function(doc, svg, x, y, options) {
       this.getVHeight = function() {
         return viewBox[3];
       };
-      this.drawMarker = function(isClip, isMask, posArray, strokeWidth) {
+      this.drawMarker = function(isClip, isMask, posArray, strokeWidth, isStart) {
         doc.save();
         let orient = this.attr('orient'),
             units = this.attr('markerUnits'),
-            rotate = (orient === 'auto' ? posArray[2] : (parseFloat(orient) || 0) * Math.PI / 180),
+            rotate = (orient === 'auto' || orient === 'auto-start-reverse' ? posArray[2] : (parseFloat(orient) || 0) * Math.PI / 180),
             scale = (units === 'userSpaceOnUse' ? 1 : strokeWidth);
+        if (orient === 'auto-start-reverse' && isStart) {
+          // reverse the start marker
+          rotate += Math.PI
+        }
         doc.transform(Math.cos(rotate) * scale, Math.sin(rotate) * scale, -Math.sin(rotate) * scale, Math.cos(rotate) * scale, posArray[0], posArray[1]);
         let refX = this.getLength('refX', this.getVWidth(), 0),
             refY = this.getLength('refY', this.getVHeight(), 0),


### PR DESCRIPTION
I'm using an svg marker that has `orient` attribute set to `auto-start-reverse`:
```
<marker
    ...
    orient="auto-start-reverse"
  >
    ...
  </marker>
```

This library understands `orient="auto"`, but not the `auto-start-reverse` value. I've implemented a fix - see the code changes.

Without fix:
<img width="109" height="170" alt="image" src="https://github.com/user-attachments/assets/0977e126-76e8-4704-ad5b-94625c0b43c5" />


With fix:
<img width="108" height="160" alt="image" src="https://github.com/user-attachments/assets/de663dca-b23b-48c6-9983-e843a0f6cee1" />
